### PR TITLE
ci: improve workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           java-version: 21
           distribution: zulu
-          cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        run: chmod +x ./gradlew && ./gradlew :app:assembleDebug :app:assembleStaging --stacktrace
+        run: ./gradlew :app:assembleDebug :app:assembleStaging --stacktrace
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           java-version: 21
           distribution: zulu
-          cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
         env:
@@ -34,7 +36,7 @@ jobs:
           RELEASE: true
         run: |
           echo "${{ secrets.keystore }}" | base64 -d > release.keystore
-          chmod +x ./gradlew && ./gradlew :app:packageRelease --stacktrace
+          ./gradlew :app:packageRelease --stacktrace
           rm release.keystore
 
       - name: Upload artifacts


### PR DESCRIPTION
Uses `gradle/actions/setup-gradle` action for proper caching
Removes unnecessary `chmod +x`  command as gradlew already has executable permission